### PR TITLE
Add command line interface to upload videos

### DIFF
--- a/objects/functions.php
+++ b/objects/functions.php
@@ -212,3 +212,40 @@ function cleanString($text) {
     );
     return preg_replace(array_keys($utf8), array_values($utf8), $text);
 }
+
+/**
+ * @brief return true if running in CLI, false otherwise
+ *
+ * @return boolean
+ */
+function isCommandLineInterface() {
+    return (php_sapi_name() === 'cli');
+}
+
+/**
+ * @brief show status message as text (CLI) or JSON-encoded array (web)
+ *
+ * @param array $statusarray associative array with type/message pairs
+ * @return string
+ */
+function status($statusarray) {
+    if (isCommandLineInterface()) {
+        foreach ($statusarray as $status => $message) {
+            echo $status . ":" . $message . "\n";
+        }
+    } else {
+        echo json_encode(array_map(
+            function($text) { return nl2br($text); }
+            , $statusarray));
+    }
+}
+
+/**
+ * @brief show status message and die
+ *
+ * @param array $statusarray associative array with type/message pairs
+ */
+function croak($statusarray) {
+    status($statusarray);
+    die;
+}

--- a/objects/video.php
+++ b/objects/video.php
@@ -119,7 +119,7 @@ class Video {
                 $id = $this->id;
             }
             if ($updateVideoGroups) {
-                require_once './userGroups.php';
+                require_once $global['systemRootPath'] . 'objects/userGroups.php';
                 // update the user groups
                 UserGroups::updateVideoGroups($id, $this->videoGroups);
             }

--- a/view/mini-upload-form/upload.php
+++ b/view/mini-upload-form/upload.php
@@ -7,23 +7,107 @@ if(empty($global['systemRootPath'])){
 
     require_once $configFile;
 }
+
+/*
+ *  Run the conversion script in the background when called through the web interface (the default)
+ *  For the CLI it is better to run it in the foreground to avoid swamping the system with conversion
+ *  processes during batch conversions
+ */
+$background = "&";
+
+require_once $global['systemRootPath'] . 'objects/functions.php';
+
+if (isCommandLineInterface()) {
+    $opts  = "";
+    $opts .= "u:";  // user
+    $opts .= "f:";  // file
+    $opts .= "d:";  // description
+    $opts .= "g:";  // comma-separated groups (numerical IDs) for which this video should be accessible - video will be public if left empty
+    $opts .= "c";   // copy original file (instead of move/rename)
+    $opts .= "b";   // run conversion script in background
+    $opts .= "h";   // show help message and exit
+
+    $longopts = [];
+
+    $options = getopt($opts, $longopts);
+
+    if (array_key_exists('h', $options)) {
+        print <<<'EOT'
+
+Use: php -f upload.php -u <user> -f <file> [-d <description>] [-g "group1[,group2]] [-c] [-h]
+
+    -u user     valid username
+    -f file     input filename
+    -d descr    description
+    -g group(s) comma-separated numerical groups for which this item will be visible,
+                item will be public if this is left out
+    -c          copy original to destination directory (file will be moved if this is left out)
+    -h          this help message
+
+
+EOT;
+        exit;
+    }
+
+    /*
+     * login user without password
+     */
+    $user = new User(false, $options['u'],false);
+    $user->login(true);
+
+    /*
+     * populate $_FILES to emulate POSTed file
+     */
+    $_FILES['upl']['name'] = basename($options['f']);
+    $_FILES['upl']['error'] = (is_readable($options['f'])) ? 0 : 1;
+    $_FILES['upl']['tmp_name'] = $options['f'];
+    $_FILES['upl']['size'] = filesize($options['f']);
+
+    if (!empty($options['d'])) {
+        $_FILES['upl']['description'] = $options['d'];
+    }
+    
+    if (!empty($options['g'])) {
+        $_FILES['upl']['videoGroups'] = explode(',', $options['g']);
+    }
+    
+    if (array_key_exists('c', $options)) {
+        $_FILES['upl']['copyOriginalFile'] = true;
+    }
+
+    if (!array_key_exists('b', $options)) {
+        $background="";
+    }
+
+} else {
+    header('Content-Type: application/json');
+}
+
 if (!User::canUpload()) {
-    die('{"status":"error", "msg":"Only logged users can upload"}');
+    //die('{"status":"error", "msg":"Only logged users can upload"}');
+    croak(["status" => "error"
+        , "msg" => "Only logged users can upload"]);
 }
 //echo "Success: login OK\n";
 
-header('Content-Type: application/json');
+//if (!isCommandLineInterface()) {
+//    header('Content-Type: application/json');
+//}
 
 // A list of permitted file extensions
 $allowed = array('mp4', 'avi', 'mov', 'mkv', 'flv', 'mp3', 'wav', 'm4v', 'webm');
 
 if (isset($_FILES['upl']) && $_FILES['upl']['error'] == 0) {
 
+    $updateVideoGroups = false;
+
     //echo "Success: \$_FILES OK\n";
     $extension = pathinfo($_FILES['upl']['name'], PATHINFO_EXTENSION);
 
     if (!in_array(strtolower($extension), $allowed)) {
-        echo '{"status":"error", "msg":"File extension error [' . $_FILES['upl']['name'] . '], we allow only (' . implode(",", $allowed) . ')"}';
+        //echo '{"status":"error", "msg":"File extension error [' . $_FILES['upl']['name'] . '], we allow only (' . implode(",", $allowed) . ')"}';
+        status(["status" => "error"
+            , "msg" => "File extension error (" . $_FILES['upl']['name'] . "), we allow only (" . implode(",", $allowed) . ")"]);
         exit;
     }
 
@@ -53,28 +137,57 @@ if (isset($_FILES['upl']) && $_FILES['upl']['error'] == 0) {
         $video->setType("video");
     }
     $video->setStatus('e');
-    $id = $video->save();
-    /**
-     * This is when is using in a non uploaded movie
+
+    /*
+     * set visibility for private videos
      */
-    if (!empty($_FILES['upl']['dontMoveUploadedFile'])) {
+    if (array_key_exists('videoGroups', $_FILES['upl'])) {
+        $video->setVideoGroups($_FILES['upl']['videoGroups']);
+        $updateVideoGroups = true;
+    }
+
+    /*
+     * set description (if given)
+     */
+    if (!empty($_FILES['upl']['description'])) {
+        $video->setDescription($_FILES['upl']['description']);
+    }
+
+    $id = $video->save($updateVideoGroups);
+
+    /**
+     * Copy, rename or move original file
+     *
+     * copy:   used from command line when -c option is included
+     * rename: used with files which were downloaded directly into the videos directory (from other media sites)
+     * move:   default, used with uploaded files
+     */
+    if (array_key_exists('copyOriginalFile', $_FILES['upl'])) {
+        if (!copy($_FILES['upl']['tmp_name'], "{$global['systemRootPath']}videos/original_" . $filename)) {
+            die("Error on copy(" . $_FILES['upl']['tmp_name'] . ", " . "{$global['systemRootPath']}videos/original_" . $filename . ")");
+        }
+    } else if (array_key_exists('dontMoveUploadedFile', $_FILES['upl'])) {
         if (!rename($_FILES['upl']['tmp_name'], "{$global['systemRootPath']}videos/original_" . $filename)) {
-            die("Error on rename file(" . $_FILES['upl']['tmp_name'] . ", " . "{$global['systemRootPath']}videos/original_" . $filename . ")");
+            die("Error on rename(" . $_FILES['upl']['tmp_name'] . ", " . "{$global['systemRootPath']}videos/original_" . $filename . ")");
         }
     } else if (!move_uploaded_file($_FILES['upl']['tmp_name'], "{$global['systemRootPath']}videos/original_" . $filename)) {
         die("Error on move_uploaded_file(" . $_FILES['upl']['tmp_name'] . ", " . "{$global['systemRootPath']}videos/original_" . $filename . ")");
     }
 
-    $cmd = "/usr/bin/php -f {$global['systemRootPath']}view/mini-upload-form/videoEncoder.php {$filename} {$id} {$type} > /dev/null 2>/dev/null &";
+    $cmd = "/usr/bin/php -f {$global['systemRootPath']}view/mini-upload-form/videoEncoder.php {$filename} {$id} {$type} > /dev/null 2>/dev/null {$background}";
     //echo "** executing command {$cmd}\n";
     exec($cmd);
 
     //exec("/usr/bin/php -f videoEncoder.php {$_FILES['upl']['tmp_name']} {$filename}  1> {$global['systemRootPath']}videos/{$filename}_progress.txt  2>&1", $output, $return_val);
     //var_dump($output, $return_val);
 
-    echo '{"status":"success", "msg":"Your video (' . $filename . ') is encoding <br> ' . $cmd . '", "filename":"' . $filename . '", "duration":"' . $duration . '"}';
+    //echo '{"status":"success", "msg":"Your video (' . $filename . ') is encoding <br> ' . $cmd . '", "filename":"' . $filename . '", "duration":"' . $duration . '"}';
+    status(["status" => "success"
+        , "msg" => "Your video ($filename) is encoding \n $cmd"
+        , "filename" => "$filename", "duration" => "$duration"]);
     exit;
 }
 
-echo '{"status":"error", "msg":' . json_encode($_FILES) . ', "type":"$_FILES Error"}';
+//echo '{"status":"error", "msg":' . json_encode($_FILES) . ', "type":"$_FILES Error"}';
+status(["status" => "error", "msg" => print_r($_FILES,true), "type" => '$_FILES Error']);
 exit;

--- a/view/mini-upload-form/videoEncoder.php
+++ b/view/mini-upload-form/videoEncoder.php
@@ -38,7 +38,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
         eval('$ffmpeg ="' . $value . '";');
         $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.{$key} && rm -f {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt && {$ffmpeg}";
         echo "** executing command {$cmd}\n";
-        exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
+        exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
         if ($return_val !== 0) {
             echo "\\n **AUDIO ERROR**\n", print_r($output, true);
             error_log($cmd . "\n" . print_r($output, true));
@@ -56,7 +56,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
                 //$ffmpeg = "ffmpeg -i {$pathFileName} -filter_complex \"[0:a]showwaves=s=858x480:mode=line,format=yuv420p[v]\" -map \"[v]\" -map 0:a -c:v libx264 -c:a copy {$destinationFile}";
                 $cmd = "rm -f $destinationFile && rm -f {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt && {$ffmpeg}";
                 echo "** executing command {$cmd}\n";
-                exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt  2>&1", $output, $return_val);
+                exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt  2>&1", $output, $return_val);
                 if ($return_val !== 0) {
                     echo "\\n **Spectrum ERROR**\n", print_r($output, true);
                     error_log($cmd . "\n" . print_r($output, true));
@@ -68,7 +68,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
                     eval('$ffmpeg ="' . $videoConverter['webm'] . '";');
                     $cmd = "rm -f $destinationFile && rm -f {$global['systemRootPath']}videos/{$filename}_progress_webm.txt && {$ffmpeg}";
                     echo "** executing command {$cmd}\n";
-                    exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_webm.txt  2>&1", $output, $return_val);
+                    exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_webm.txt  2>&1", $output, $return_val);
                     if ($return_val !== 0) {
                         echo "\\n **VIDEO ERROR**\n", print_r($output, true);
                         error_log($cmd . "\n" . print_r($output, true));
@@ -103,7 +103,7 @@ foreach ($videoConverter as $key => $value) {
     eval('$ffmpeg ="' . $value . '";');
     $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.{$key} && rm -f {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt && {$ffmpeg}";
     echo "** executing command {$cmd}\n";
-    exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
+    exec($cmd . " < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
     if ($return_val !== 0) {
         echo "\\n **VIDEO ERROR**\n", print_r($output, true);
         error_log($cmd . "\n" . print_r($output, true));
@@ -136,7 +136,7 @@ if (empty($type) || $type == 'img') {
 
     $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.jpg && {$ffmpeg}";
     echo "** executing command {$cmd}\n";
-    exec($cmd . " 2>&1", $output, $return_val);
+    exec($cmd . " < /dev/null 2>&1", $output, $return_val);
     if ($return_val !== 0) {
         echo "\\n**IMG ERROR**\n", print_r($output, true);
         error_log($cmd . "\n" . print_r($output, true));


### PR DESCRIPTION
Add command line interface to upload videos. Use php -f upload.php -- -h in `view/mini-upload-form` for instructions. 

The -g parameter takes a comma-separated list of *NUMERICAL* groups (group IDs, actually) as argument, this due to the current absence of an easy way to get groups by their name, this can be changed when such has been implemented. I have not done this yet as there are things of higher concern, eg. the *abundance of SQL injection opportunities* in the code...).

```
Use: php -f upload.php -u <user> -f <file> [-d <description>] [-g "group1[,group2]] [-c] [-h]

    -u user     valid username
    -f file     input filename
    -d descr    description
    -g group(s) comma-separated numerical groups for which this item will be visible,
                item will be public if this is left out
    -c          copy original to destination directory (file will be moved if this is left out)
    -h          this help message
```

The easiest way to use this is to call the php code from a script, like so:

```sh
#!/bin/bash
srcdir="/var/src/YouPHPTube"

pushd "${srcdir}/view/mini-upload-form/" > /dev/null
sudo -u www-data php -f upload.php -- "$@"
popd > /dev/null
```

(adjust `srcdir` and `www-data` to your environment)