### PR TITLE
Add video rotate command

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -80,6 +80,7 @@
     RewriteRule    ^refreshVideo$ objects/videoRefresh.json.php    [NC,L]
     RewriteRule    ^setStatusVideo$ objects/videoStatus.json.php    [NC,L]
     RewriteRule    ^reencodeVideo$ objects/videoReencode.json.php    [NC,L]
+    RewriteRule    ^rotateVideo$ objects/videoRotate.json.php    [NC,L]
     RewriteRule    ^addViewCountVideo$ objects/videoAddViewCount.json.php    [NC,L]
 
 

--- a/install/database.sql
+++ b/install/database.sql
@@ -58,6 +58,8 @@ CREATE TABLE IF NOT EXISTS `videos` (
   `filename` VARCHAR(255) NOT NULL,
   `duration` VARCHAR(15) NOT NULL,
   `type` ENUM('audio', 'video') NOT NULL DEFAULT 'video',
+  `rotation` SMALLINT DEFAULT 0,
+  `zoom` SMALLINT DEFAULT 1,
   `videoDownloadedLink` VARCHAR(255) NULL,
   `order` INT UNSIGNED NOT NULL DEFAULT 1,
   PRIMARY KEY (`id`),

--- a/install/database.sql
+++ b/install/database.sql
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS `videos` (
   `duration` VARCHAR(15) NOT NULL,
   `type` ENUM('audio', 'video') NOT NULL DEFAULT 'video',
   `rotation` SMALLINT DEFAULT 0,
-  `zoom` SMALLINT DEFAULT 1,
+  `zoom` FLOAT DEFAULT 1,
   `videoDownloadedLink` VARCHAR(255) NULL,
   `order` INT UNSIGNED NOT NULL DEFAULT 1,
   PRIMARY KEY (`id`),

--- a/objects/video.php
+++ b/objects/video.php
@@ -21,6 +21,8 @@ class Video {
     private $users_id;
     private $categories_id;
     private $type;
+    private $rotation;
+    private $zoom;
     private $videoDownloadedLink;
     static $types = array('webm', 'mp4', 'mp3', 'ogg');
     private $videoGroups;
@@ -48,6 +50,9 @@ class Video {
         if (!empty($filename)) {
             $this->filename = $filename;
         }
+
+        $this->rotation = 0;
+        $this->zoom = 1;
     }
 
     function addView() {
@@ -119,7 +124,7 @@ class Video {
                 $id = $this->id;
             }
             if ($updateVideoGroups) {
-                require_once './userGroups.php';
+                require_once $global['systemRootPath'] . 'objects/userGroups.php';
                 // update the user groups
                 UserGroups::updateVideoGroups($id, $this->videoGroups);
             }
@@ -151,6 +156,45 @@ class Video {
 
     function setType($type) {
         $this->type = $type;
+    }
+
+    function setRotation($rotation) {
+        $saneRotation = intval($rotation) % 360;
+
+        if (!empty($this->id)) {
+            global $global;
+            $sql = "UPDATE videos SET rotation = '{$saneRotation}', modified = now() WHERE id = {$this->id} ";
+            if (!$global['mysqli']->query($sql)) {
+                die('Error on update Rotation: (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
+            }
+        }
+        $this->rotation = $saneRotation;
+    }
+
+    function getRotation() {
+        return $this->rotation;
+    }
+
+    function setZoom($zoom) {
+        $saneZoom = abs(floatval($zoom));
+
+        if ($saneZoom < 0.1 || $saneZoom > 10) {
+            die('Zoom level must be between 0.1 and 10');
+        }
+
+        if (!empty($this->id)) {
+            global $global;
+            $sql = "UPDATE videos SET zoom = '{$saneZoom}', modified = now() WHERE id = {$this->id} ";
+            if (!$global['mysqli']->query($sql)) {
+                die('Error on update Zoom: (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
+            }
+        }
+
+        $this->zoom = $saneZoom;
+    }
+
+    function getZoom() {
+        return $this->zoom;
     }
 
     static private function getUserGroupsCanSeeSQL() {

--- a/objects/videoRotate.json.php
+++ b/objects/videoRotate.json.php
@@ -1,0 +1,41 @@
+<?php
+header('Content-Type: application/json');
+
+if(empty($global['systemRootPath'])){
+    $global['systemRootPath'] = "../";
+}
+require_once $global['systemRootPath'] .'videos/configuration.php';
+require_once $global['systemRootPath'] . 'objects/user.php';
+require_once $global['systemRootPath'] . 'objects/functions.php';
+if (!User::isAdmin() || empty($_POST['id'])) {
+    die('{"error":"'.__("Permission denied").'"}');
+}
+
+$type = !empty($_POST['type'])?$_POST['type']:"";
+
+require_once 'video.php';
+
+$obj = new Video("", "", $_POST['id']);
+if(empty($obj)){
+    croak(["error" => "Video not found"]);
+}
+
+$currentRotation = $obj->getRotation();
+$newRotation = $currentRotation;
+$status = ["success" => "video rotated"];
+
+switch ($type) {
+case 'left':
+    $newRotation = ($currentRotation - 90) % 360;
+    $obj->setRotation($newRotation);
+    break;
+case 'right':
+    $newRotation = ($currentRotation + 90) % 360;
+    $obj->setRotation($newRotation);
+    break;
+default:
+    $status = ["error" => "I don't know how to rotate '{$type}'"];
+    break;
+}
+
+status($status);

--- a/view/bootstrap/css/bootstrap.css
+++ b/view/bootstrap/css/bootstrap.css
@@ -1124,6 +1124,9 @@ img {
   max-width: 100%;
   height: auto;
 }
+.img-portrait {
+  transform: scale(0.56) rotate(90deg);
+}
 .img-rounded {
   border-radius: 6px;
 }
@@ -5813,9 +5816,15 @@ button.list-group-item-danger.active:focus {
 .embed-responsive-16by9 {
   padding-bottom: 56.25%;
 }
+
+.embed-responsive-9by16 {
+  padding-bottom: 100%;
+}
+
 .embed-responsive-4by3 {
   padding-bottom: 75%;
 }
+
 .well {
   min-height: 20px;
   padding: 19px;

--- a/view/css/player.css
+++ b/view/css/player.css
@@ -52,6 +52,10 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', e
     background-color: rgba(159,159,159,.3);
 }
 
+.vjs-rotate90 {
+    rotate: 90;
+    zoom: 1.0;
+}
 
 /* Ad Elements */
 #adUrl{

--- a/view/include/video.php
+++ b/view/include/video.php
@@ -1,5 +1,16 @@
 <?php
 $playNowVideo = $video;
+$transformation = "{rotate:" . $video['rotation'] . ", zoom: " . $video['zoom'] . "}";
+if ($video['rotation'] === "90" || $video['rotation'] === "270") {
+    $aspectRatio = "9:16";
+    $vjsClass = "vjs-9-16";
+    $embedResponsiveClass = "embed-responsive-9by16";
+} else {
+    $aspectRatio = "16:9";
+    $vjsClass = "vjs-16-9";
+    $embedResponsiveClass = "embed-responsive-16by9";
+}
+
 if (!empty($ad)) {
     $playNowVideo = $ad;
     $logId = Video_ad::log($ad['id']);
@@ -8,13 +19,14 @@ if (!empty($ad)) {
 <div class="row main-video">
     <div class="col-xs-12 col-sm-12 col-lg-2"></div>
     <div class="col-xs-12 col-sm-12 col-lg-8">
-        <div align="center" class="embed-responsive embed-responsive-16by9 <?php
+    <div align="center" class="embed-responsive <?php
+        echo $embedResponsiveClass;
         if (!empty($logId)) {
-            echo "ad";
+            echo " ad";
         }
         ?>">
             <video poster="<?php echo $poster; ?>" controls crossorigin 
-                   class="embed-responsive-item video-js vjs-default-skin vjs-16-9 vjs-big-play-centered" id="mainVideo"  data-setup='{ aspectRatio: "16:9" }'>
+            class="embed-responsive-item video-js vjs-default-skin <?php echo $vjsClass; ?> vjs-big-play-centered" id="mainVideo"  data-setup='{ aspectRatio: "<?php echo $aspectRatio; ?>" }'>
                 <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $playNowVideo['filename']; ?>.mp4" type="video/mp4">
                 <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $playNowVideo['filename']; ?>.webm" type="video/webm">
                 <p><?php echo __("If you can't view this video, your browser does not support HTML5 videos"); ?></p>
@@ -43,7 +55,10 @@ if (!empty($ad)) {
     var isPlayingAd = false;
     $(document).ready(function () {
         fullFuration = strToSeconds('<?php echo $ad['duration']; ?>');
-        player = videojs('mainVideo').ready(function () {
+        player = videojs('mainVideo');
+
+        player.zoomrotate(<?php echo $transformation; ?>);
+        player.ready(function () {
 <?php
 if ($config->getAutoplay()) {
     echo "this.play();";

--- a/view/js/video.js/video-js.css
+++ b/view/js/video.js/video-js.css
@@ -284,6 +284,9 @@
 .video-js.vjs-16-9 {
   padding-top: 56.25%; }
 
+.video-js.vjs-9-16 {
+  padding-top: 100%; }
+
 .video-js.vjs-4-3 {
   padding-top: 75%; }
 

--- a/view/js/videojs-rotatezoom/videojs.zoomrotate.js
+++ b/view/js/videojs-rotatezoom/videojs.zoomrotate.js
@@ -1,0 +1,73 @@
+console.log('zoomrotate: Start');
+
+(function(){
+    var defaults, extend;
+    console.log('zoomrotate: Init defaults');
+    defaults = {
+      zoom: 1,
+      rotate: 0,
+      debug: true
+    };
+    extend = function() {
+      var args, target, i, object, property;
+      args = Array.prototype.slice.call(arguments);
+      target = args.shift() || {};
+      for (i in args) {
+        object = args[i];
+        for (property in object) {
+          if (object.hasOwnProperty(property)) {
+            if (typeof object[property] === 'object') {
+              target[property] = extend(target[property], object[property]);
+            } else {
+              target[property] = object[property];
+            }
+          }
+        }
+      }
+      return target;
+    };
+
+  /**
+    * register the zoomrotate plugin
+    */
+    videojs.plugin('zoomrotate', function(settings){
+        if (defaults.debug) console.log('zoomrotate: Register init');
+
+        var options, player, video, poster;
+        options = extend(defaults, settings);
+
+        /* Grab the necessary DOM elements */
+        player = this.el();
+        video = this.el().getElementsByTagName('video')[0];
+        poster = this.el().getElementsByTagName('div')[1]; // div vjs-poster
+
+        if (options.debug) console.log('zoomrotate: '+video.style);
+        if (options.debug) console.log('zoomrotate: '+poster.style);
+        if (options.debug) console.log('zoomrotate: '+options.rotate);
+        if (options.debug) console.log('zoomrotate: '+options.zoom);
+
+        /* Array of possible browser specific settings for transformation */
+        var properties = ['transform', 'WebkitTransform', 'MozTransform',
+                          'msTransform', 'OTransform'],
+            prop = properties[0];
+
+        /* Iterators */
+        var i,j;
+
+        /* Find out which CSS transform the browser supports */
+        for(i=0,j=properties.length;i<j;i++){
+          if(typeof player.style[properties[i]] !== 'undefined'){
+            prop = properties[i];
+            break;
+          }
+        }
+
+        /* Let's do it */
+        player.style.overflow = 'hidden';
+        video.style[prop]='scale('+options.zoom+') rotate('+options.rotate+'deg)';
+        poster.style[prop]='scale('+options.zoom+') rotate('+options.rotate+'deg)';
+        if (options.debug) console.log('zoomrotate: Register end');
+    });
+})();
+
+console.log('zoomrotate: End');

--- a/view/mini-upload-form/videoEncoder.php
+++ b/view/mini-upload-form/videoEncoder.php
@@ -38,7 +38,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
         eval('$ffmpeg ="' . $value . '";');
         $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.{$key} && rm -f {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt && {$ffmpeg}";
         echo "** executing command {$cmd}\n";
-        exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
+        exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
         if ($return_val !== 0) {
             echo "\\n **AUDIO ERROR**\n", print_r($output, true);
             error_log($cmd . "\n" . print_r($output, true));
@@ -56,7 +56,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
                 //$ffmpeg = "ffmpeg -i {$pathFileName} -filter_complex \"[0:a]showwaves=s=858x480:mode=line,format=yuv420p[v]\" -map \"[v]\" -map 0:a -c:v libx264 -c:a copy {$destinationFile}";
                 $cmd = "rm -f $destinationFile && rm -f {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt && {$ffmpeg}";
                 echo "** executing command {$cmd}\n";
-                exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt  2>&1", $output, $return_val);
+                exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_mp4.txt  2>&1", $output, $return_val);
                 if ($return_val !== 0) {
                     echo "\\n **Spectrum ERROR**\n", print_r($output, true);
                     error_log($cmd . "\n" . print_r($output, true));
@@ -68,7 +68,7 @@ if ($type == 'audio' || $type == 'mp3' || $type == 'ogg') {
                     eval('$ffmpeg ="' . $videoConverter['webm'] . '";');
                     $cmd = "rm -f $destinationFile && rm -f {$global['systemRootPath']}videos/{$filename}_progress_webm.txt && {$ffmpeg}";
                     echo "** executing command {$cmd}\n";
-                    exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_webm.txt  2>&1", $output, $return_val);
+                    exec($cmd . "  < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_webm.txt  2>&1", $output, $return_val);
                     if ($return_val !== 0) {
                         echo "\\n **VIDEO ERROR**\n", print_r($output, true);
                         error_log($cmd . "\n" . print_r($output, true));
@@ -103,7 +103,7 @@ foreach ($videoConverter as $key => $value) {
     eval('$ffmpeg ="' . $value . '";');
     $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.{$key} && rm -f {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt && {$ffmpeg}";
     echo "** executing command {$cmd}\n";
-    exec($cmd . "  1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
+    exec($cmd . " < /dev/null 1> {$global['systemRootPath']}videos/{$filename}_progress_{$key}.txt  2>&1", $output, $return_val);
     if ($return_val !== 0) {
         echo "\\n **VIDEO ERROR**\n", print_r($output, true);
         error_log($cmd . "\n" . print_r($output, true));
@@ -136,7 +136,7 @@ if (empty($type) || $type == 'img') {
 
     $cmd = "rm -f {$global['systemRootPath']}videos/{$filename}.jpg && {$ffmpeg}";
     echo "** executing command {$cmd}\n";
-    exec($cmd . " 2>&1", $output, $return_val);
+    exec($cmd . " < /dev/null 2>&1", $output, $return_val);
     if ($return_val !== 0) {
         echo "\\n**IMG ERROR**\n", print_r($output, true);
         error_log($cmd . "\n" . print_r($output, true));

--- a/view/modeGallery.php
+++ b/view/modeGallery.php
@@ -68,6 +68,8 @@ $totalPages = ceil($total / $_POST['rowCount']);
                     <div class="row">
                         <?php
                         foreach ($videos as $value) {
+                            $img_portrait = ($value['rotation'] === "90" || $value['rotation'] === "270") ? "img-portrait" : "";
+
                             ?>
                             <div class="col-lg-2 col-md-3 col-sm-4 col-xs-6 galleryVideo ">
                                 <a href="<?php echo $global['webSiteRootURL']; ?>video/<?php echo $value['clean_title']; ?>" title="<?php echo $value['title']; ?>" class="">
@@ -78,7 +80,7 @@ $totalPages = ceil($total / $_POST['rowCount']);
                                         $poster = "{$global['webSiteRootURL']}view/img/audio_wave.jpg";
                                     }
                                     ?>
-                                    <img src="<?php echo $poster; ?>" alt="<?php echo $value['title']; ?>" class="img img-responsive " height="130px" />
+                                        <img src="<?php echo $poster; ?>" alt="<?php echo $value['title']; ?>" class="img img-responsive <?php echo $img_portrait; ?> " height="130px" />
                                     <span class="duration"><?php echo Video::getCleanDuration($value['duration']); ?></span>
                                 </a>
                                 <a href="<?php echo $global['webSiteRootURL']; ?>video/<?php echo $value['clean_title']; ?>" title="<?php echo $value['title']; ?>">

--- a/view/modeYoutube.php
+++ b/view/modeYoutube.php
@@ -86,6 +86,7 @@ if(!empty($_GET['catName'])){
         ?>
         <link href="<?php echo $global['webSiteRootURL']; ?>js/video.js/video-js.min.css" rel="stylesheet" type="text/css"/>
         <script src="<?php echo $global['webSiteRootURL']; ?>js/video.js/video.js" type="text/javascript"></script>
+        <script src="<?php echo $global['webSiteRootURL']; ?>js/videojs-rotatezoom/videojs.zoomrotate.js" type="text/javascript"></script>
         <link href="<?php echo $global['webSiteRootURL']; ?>css/player.css" rel="stylesheet" type="text/css"/>
         <link href="<?php echo $global['webSiteRootURL']; ?>css/social.css" rel="stylesheet" type="text/css"/>
 
@@ -110,6 +111,7 @@ if(!empty($_GET['catName'])){
                     ?>
                     <?php
                     require "{$global['systemRootPath']}view/include/{$video['type']}.php";
+                    $img_portrait = ($video['rotation'] === "90" || $video['rotation'] === "270") ? "img-portrait" : "";
                     ?>
                     <div class="row">
                         <div class="col-xs-12 col-sm-1 col-md-1 col-lg-1"></div>
@@ -117,7 +119,7 @@ if(!empty($_GET['catName'])){
                             <div class="row bgWhite">
                                 <div class="row divMainVideo">
                                     <div class="col-xs-4 col-sm-4 col-lg-4">
-                                        <img src="<?php echo $poster; ?>" alt="<?php echo $video['title']; ?>" class="img img-responsive" height="130px" itemprop="thumbnail" /> 
+                                    <img src="<?php echo $poster; ?>" alt="<?php echo $video['title']; ?>" class="img img-responsive <?php echo $img_portrait; ?> " height="130px" itemprop="thumbnail" /> 
                                         <time class="duration" itemprop="duration" datetime="<?php echo Video::getItemPropDuration($video['duration']); ?>" ><?php echo Video::getCleanDuration($video['duration']); ?></time>
                                         <meta itemprop="thumbnailUrl" content="<?php echo $img; ?>" />
                                         <meta itemprop="contentURL" content="<?php echo $global['webSiteRootURL'], $catLink, "video/", $video['clean_title']; ?>" />
@@ -513,11 +515,13 @@ if(!empty($_GET['catName'])){
                                         <?php
                                         if ($autoPlayVideo['type'] !== "audio") {
                                             $img = "{$global['webSiteRootURL']}videos/{$autoPlayVideo['filename']}.jpg";
+                                            $img_portrait = ($autoPlayVideo['rotation'] === "90" || $autoPlayVideo['rotation'] === "270") ? "img-portrait" : "";
                                         } else {
                                             $img = "{$global['webSiteRootURL']}view/img/audio_wave.jpg";
+                                            $img_portrait = "";
                                         }
                                         ?>
-                                        <img src="<?php echo $img; ?>" alt="<?php echo $autoPlayVideo['title']; ?>" class="img-responsive" height="130px" itemprop="thumbnail" />
+                                            <img src="<?php echo $img; ?>" alt="<?php echo $autoPlayVideo['title']; ?>" class="img-responsive <?php echo $img_portrait; ?> " height="130px" itemprop="thumbnail" />
 
                                         <meta itemprop="thumbnailUrl" content="<?php echo $img; ?>" />
                                         <meta itemprop="contentURL" content="<?php echo $global['webSiteRootURL'], $catLink, "video/", $autoPlayVideo['clean_title']; ?>" />
@@ -577,11 +581,13 @@ if(!empty($_GET['catName'])){
                                             <?php
                                             if ($value['type'] !== "audio") {
                                                 $img = "{$global['webSiteRootURL']}videos/{$value['filename']}.jpg";
+                                                $img_portrait = ($value['rotation'] === "90" || $value['rotation'] === "270") ? "img-portrait" : "";
                                             } else {
                                                 $img = "{$global['webSiteRootURL']}view/img/audio_wave.jpg";
+                                                $img_portrait = "";
                                             }
                                             ?>
-                                            <img src="<?php echo $img; ?>" alt="<?php echo $value['title']; ?>" class="img-responsive" height="130px" itemprop="thumbnail" />
+                                                <img src="<?php echo $img; ?>" alt="<?php echo $value['title']; ?>" class="img-responsive <?php echo $img_portrait; ?> " height="130px" itemprop="thumbnail" />
 
                                             <meta itemprop="thumbnailUrl" content="<?php echo $img; ?>" />
                                             <meta itemprop="contentURL" content="<?php echo $global['webSiteRootURL'], $catLink, "video/", $value['clean_title']; ?>" />
@@ -678,10 +684,11 @@ if(!empty($_GET['catName'])){
                         <div class="col-xs-12 col-sm-12 col-lg-10">
                             <?php
                             foreach ($videos as $value) {
+                                $img_portrait = ($value['rotation'] === "90" || $value['rotation'] === "270") ? "img-portrait" : "";
                                 ?>
                                 <div class="col-lg-3 col-sm-12 col-xs-12">
                                     <a href="<?php echo $global['webSiteRootURL'], $catLink; ?>video/<?php echo $value['clean_title']; ?>" title="<?php echo $value['title']; ?>">
-                                        <img src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $value['filename']; ?>.jpg" alt="<?php echo $value['title']; ?>" class="img-responsive" height="130px" />
+                                    <img src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $value['filename']; ?>.jpg" alt="<?php echo $value['title']; ?>" class="img-responsive <?php echo $img_portrait; ?> " height="130px" />
                                         <h2><?php echo $value['title']; ?></h2>
                                         <span class="glyphicon glyphicon-play-circle"></span>
                                         <span class="duration"><?php echo Video::getCleanDuration($value['duration']); ?></span>

--- a/view/videoEmbeded.php
+++ b/view/videoEmbeded.php
@@ -1,12 +1,22 @@
 <?php
 require_once '../videos/configuration.php';
 require_once $global['systemRootPath'] . 'objects/video.php';
+require_once $global['systemRootPath'] . 'objects/video_statistic.php';
 $video = Video::getVideo();
 if(empty($video)){
     die(__("Video not found"));
 }
 
-require_once $global['systemRootPath'] . 'objects/video_statistic.php';
+/*
+ * Swap aspect ratio for rotated (vvs) videos
+ */
+if ($video['rotation'] === "90" || $video['rotation'] === "270") {
+    $embedResponsiveClass = "embed-responsive-9by16";
+    $vjsClass = "vjs-9-16";
+} else {
+    $embedResponsiveClass = "embed-responsive-16by9";
+    $vjsClass = "vjs-16-9";
+}
 VideoStatistic::save($video['id']);
 $obj = new Video("", "", $video['id']);
 $resp = $obj->addView();
@@ -25,16 +35,17 @@ $resp = $obj->addView();
         <link href="<?php echo $global['webSiteRootURL']; ?>css/player.css" rel="stylesheet" type="text/css"/>
         <script src="<?php echo $global['webSiteRootURL']; ?>js/jquery-3.2.0.min.js" type="text/javascript"></script>
         <script src="<?php echo $global['webSiteRootURL']; ?>js/video.js/video.js" type="text/javascript"></script>
+        <script src="<?php echo $global['webSiteRootURL']; ?>js/videojs-rotatezoom/videojs.zoomrotate.js" type="text/javascript"></script>
         <style>
         </style>
     </head>
 
     <body>
-        <div align="center" class="embed-responsive embed-responsive-16by9 ">
+        <div align="center" class="embed-responsive <?php echo $embedResponsiveClass; ?> ">
             <?php
             if ($video['type'] == "audio") {
                 ?>
-                <audio controls class="center-block video-js vjs-default-skin vjs-big-play-centered"  id="mainAudio"  data-setup='{ "fluid": true}'
+                <audio controls class="center-block video-js vjs-default-skin vjs-big-play-centered"  id="mainAudio"  data-setup='{ "fluid": true }'
                poster="<?php echo $global['webSiteRootURL']; ?>img/recorder.gif">
                     <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $video['filename']; ?>.ogg" type="audio/ogg" />
                     <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $video['filename']; ?>.mp3" type="audio/mpeg" />
@@ -45,7 +56,7 @@ $resp = $obj->addView();
                 ?>
 
                 <video poster="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $video['filename']; ?>.jpg" controls crossorigin  width="auto" height="auto" 
-                       class="video-js vjs-default-skin vjs-big-play-centered vjs-16-9" id="mainVideo"  data-setup='{"fluid": true }'>
+                class="video-js vjs-default-skin vjs-big-play-centered <?php echo $vjsClass; ?> " id="mainVideo"  data-setup='{"fluid": true }'>
                     <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $video['filename']; ?>.mp4" type="video/mp4">
                     <source src="<?php echo $global['webSiteRootURL']; ?>videos/<?php echo $video['filename']; ?>.webm" type="video/webm">
                     <p><?php echo __("If you can't view this video, your browser does not support HTML5 videos"); ?></p>


### PR DESCRIPTION
Add video rotate command. This command does NOT rotate or reencode the video, it just changes the way the video is played in the (html5 - does not work in flash) web player. Two new columns in the videos table (rotation and zoom) indicate the way the video is to be presented to the user (zoom is not user-accessible just now). Two new buttons (rotate left and rotate right) are added to the video manager to facilitate rotation.
