### PR TITLE
remove .mp4 in name on upload

### DIFF
--- a/view/mini-upload-form/upload.php
+++ b/view/mini-upload-form/upload.php
@@ -25,7 +25,7 @@ if (isset($_FILES['upl']) && $_FILES['upl']['error'] == 0) {
     $path_parts = pathinfo($_FILES['upl']['name']);
     $mainName = preg_replace("/[^A-Za-z0-9]/", "", cleanString($path_parts['filename']));
     $filename = uniqid($mainName . "_", true);
-    $video = new Video(preg_replace("/_+/", " ", $_FILES['upl']['name']), $filename, @$_FILES['upl']['videoId']);
+    $video = new Video(substr(preg_replace("/_+/", " ", $_FILES['upl']['name']),0,-4), $filename, @$_FILES['upl']['videoId']);
     $video->setDuration($duration);
     $video->setType("video");
     $video->setStatus('a');


### PR DESCRIPTION
the direct upload allows only .mp4-files. i'm not shure if the name-length is prechecked, but you do this anywhere on filetype-check (if mp4).

if the check is after the substring, it would be possible to fail there - so in some (anyway unallowed) cases, this could cause a unproper fail - but at all, this change would save work and make it less ugly.

btw-offtopic: nice sort-changes in next-list! would be really cool, when next video stays in category..