### PR TITLE
Fix for #408 - videos with ad not playing

### DIFF
--- a/view/js/script.js
+++ b/view/js/script.js
@@ -146,7 +146,7 @@ function changeVideoSrc(vid_obj, source) {
             player.addRemoteTextTrack(source[i]);
         }
     }
-    player.updateSrc(srcs);
+    player.src(srcs);
     vid_obj.load();
     player.play();
                     


### PR DESCRIPTION
Found the problem.

File: view/js/script.js - Row 149
Replaced: "player.updateSrc(srcs);"
To: "player.src(srcs);"

Now it's working.