### PR TITLE
Update stats.json.php

### DIFF
--- a/plugin/Live/stats.json.php
+++ b/plugin/Live/stats.json.php
@@ -74,7 +74,7 @@ foreach ($lifeStream as $value){
         $UserPhoto = $u->getPhoto();
         $obj->applications[] = array("key"=>$value->name, "users"=>$users, "name"=>$userName, "user"=>$user, "photo"=>$photo, "UserPhoto"=>$UserPhoto, "title"=>$row['title'], 'channelName'=>$channelName);
         if($value->name === $_POST['name']){
-            $obj->error = (!empty($value->publishing))?false:true;
+            $obj->error = property_exists($value, 'publishing')?false:true;
             $obj->msg = (!$obj->error)?"ONLINE":"Waiting for Streamer";
             $obj->stream = $value;
             $obj->nclients = intval($value->nclients);


### PR DESCRIPTION
Situation: Live stream counter does not work. 
Origin: "publishing" property is always empty when existing, or does not exist if stream publish is not in progress. 
In such situation, empty() method on this property always return true.

Proposed correction:
  File: stats.json.php
  Line: 77
  From code: $obj->error = (!empty($value->publishing))?false:true;
  To code: $obj->error = property_exists($value, 'publishing')?false:true;

Live stream counter works after this change.