### PR TITLE
Enabling force downloading at  video manager

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -156,6 +156,7 @@ Deny from all
     RewriteRule    ^reencodeVideo$ objects/videoReencode.json.php    [NC,L]
     RewriteRule    ^rotateVideo$ objects/videoRotate.json.php    [NC,L]
     RewriteRule    ^addViewCountVideo$ objects/videoAddViewCount.json.php    [NC,L]
+    RewriteRule    ^fetch/([A-Za-z_0-9]+)/([A-Za-z0-9-._]+)$ objects/download.php?filetype=$1&clean_title=$2    [QSA]
 
 
     # Subscribes

--- a/objects/download.php
+++ b/objects/download.php
@@ -1,0 +1,50 @@
+<?php
+global $global, $config;
+if(!isset($global['systemRootPath'])){
+    require_once '../videos/configuration.php';
+}
+
+require_once $global['systemRootPath'] . 'objects/video.php';
+
+if(isset($_GET['clean_title']))
+$v=Video::getVideoFromCleanTitle($_GET['clean_title']); 
+else
+$v=false;
+
+if($v)
+{
+    $video=new video($v['title'], $v['filename'], $v['id']);
+    switch($_GET['filetype'])
+    {
+    
+        case "mp4_Low":
+            $filetype="_Low.mp4"; 
+        break;
+        case "mp4_SD":
+            $filetype="_SD.mp4"; 
+        break;
+        case "mp4_HD":
+            $filetype="_HD.mp4"; 
+        break;
+        default:
+            $filetype=".".$_GET['filetype'];
+        
+    }
+    $file=$video->getSourceFile($video->getFileName(), $filetype);
+    
+    header( 'Expires: Mon, 1 Apr 1974 05:00:00 GMT' );
+    header( 'Pragma: no-cache' );
+    header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
+    header( 'Content-Description: File Download' );
+    header( 'Content-Type: application/octet-stream' );
+    header( 'Content-Length: '.filesize( $file['path'] ) );
+    header( 'Content-Disposition: attachment; filename="'.$_GET['clean_title'].$filetype.'"' );
+    header( 'Content-Transfer-Encoding: binary' );
+    if(file_exists($file['path']))
+    readfile( $file['path'] );  
+    else
+    print ""; 
+    exit();    
+}
+
+?>

--- a/view/managerVideos.php
+++ b/view/managerVideos.php
@@ -891,7 +891,7 @@ if (User::isAdmin()) {
                                                     var pluginsButtons = '<br><?php echo YouPHPTubePlugin::getVideosManagerListButton(); ?>';
                                                     var download = "";
                                                     for (var k in row.videosURL) {
-                                                        download += '<a href="' + row.videosURL[k].url + '?download=1" class="btn btn-default btn-xs" ><span class="fa fa-download " aria-hidden="true"></span> ' + k + '</a><br>';
+                                                        download += '<a href="/fetch/' + k  +'/'+row.clean_title+ '?download=<?=uniqid();?>" class="btn btn-default btn-xs" ><span class="fa fa-download " aria-hidden="true"></span> ' + k + '</a><br>';
                                                     }
 
                                                     if (row.status == "i") {


### PR DESCRIPTION
My users are like...  not very teach saavy, so when they clicked at the download links at the video manager, and then the video shows up, instead of downloading, they complain about the functionality. 

So, I modified the video manager  and added a download.php called vía .htaccess route fetch/(filetype)/clean_title and also provides a friendlier SEO and cut and paste download url... 
