### PR TITLE
bugfix - display non-latin filenames correctly in DirectUpload page

### DIFF
--- a/objects/listFiles.json.php
+++ b/objects/listFiles.json.php
@@ -27,8 +27,8 @@ if (!empty($_POST['path'])) {
             $path_parts = pathinfo($value);
             $obj = new stdClass();
             $obj->id = $id++;
-            $obj->path = utf8_encode($value);
-            $obj->name = utf8_encode($path_parts['basename']);
+            $obj->path = mb_convert_encoding($value, 'UTF-8');
+            $obj->name = mb_convert_encoding($path_parts['basename'], 'UTF-8');
             $files[] = $obj;
         }
     }


### PR DESCRIPTION
Hi Daniel,

Just find a display issue to  direct upload my local files. 

It looks like utf8_encode  only did convertion from  iso8599-1  to UTF8.  
change to use  mbstring_convert_encoding  which   convert from mb_internal_encoding to UTF8. which is more friendly to non-latin locals. 



